### PR TITLE
Update staging_plate.scad to aid tapping and build various size plates

### DIFF
--- a/lumen/staging_plate.scad
+++ b/lumen/staging_plate.scad
@@ -11,7 +11,10 @@ You can also generate custom staging plates, for example, if you wanted one with
 The staging_plate() module has a bunch of arguments for configuring a specific staging plate.
 
 Dimensional arguments:
-* width, height, thickness: the overall dimensions.
+* width, thickness: the overall dimensions.
+* plate_height : Height of an indivdual plate unit (120 = Opulo standard)
+* plate_count  : number of plates required
+* camera_height : where the camera hole is required. (60 is Opulo standard)
 * fillet_radius: the amount to fillet the outside edges of the plate.
 * center: if true, the plate will be centered on the coordinate origin. If false, the plate's bottom-left corner will be placed on the coordinate origin.
 
@@ -20,6 +23,9 @@ Accessory grid arguments:
 * grid_spacing: the spacing between each of the accessory holes.
 * grid_offset: the offset from the edge of the staging plate where the accessory hole grid begins.
 * grid_hole_diameter: the diameter of each accessory hole. This should be set according to which machine screws you want to use for mounting accessories.
+* tapping_hole_diameter : the diameter of each accessory hole. This value required form M3 tapping
+* is_tapping : true if we want tapping_hole_diameter hole or false for grid_hole_diameter
+* camera_hole_tapping_exclusions : The number of holes not to tap because the camera occupies the space
 
 Mounting hole arguments:
 * mounting_holes: if true, holes for mounting the plate to the machine's frame will be included.
@@ -38,8 +44,17 @@ Author: Alethea Flowers
 
 
 
-module staging_plate(width = 600, height = 120, thickness = 3, fillet_radius = 6, center = true, grid_holes = true, grid_spacing=[30, 15], grid_offset = [15, 15], grid_hole_diameter = 3.4, mounting_holes = true, mounting_hole_offset = [10, 10], mounting_hole_diameter=5.5, camera_hole=true, camera_hole_diameter = 45) {
+module staging_plate(width = 600, plate_height = 120, plate_count =1, camera_height = 60, thickness = 3, fillet_radius = 6, center = true, grid_holes = true, grid_spacing=[30, 15], grid_offset = [15, 15], grid_hole_diameter = 3.4, tapping_hole_diameter = 2.5, is_tapping = true, mounting_holes = true, mounting_hole_offset = [10, 10], mounting_hole_diameter=5.5, camera_hole=true, camera_hole_diameter = 45, camera_hole_tapping_exclusions = 5) {
+    height = plate_height * plate_count;
     offset = center ? [-width / 2, -height / 2] : [0, 0];
+    
+    echo("width          : " , width);
+    echo("plate_height   : " , plate_height);
+    echo("plate_count    : " , plate_count);
+
+    echo("overall height : " , height);
+    echo("camera_height  : " , camera_height);
+    
     color("black") {
         translate(offset) {
             linear_extrude(thickness) {
@@ -48,8 +63,8 @@ module staging_plate(width = 600, height = 120, thickness = 3, fillet_radius = 6
                         square([width, height]);
                     }
                     if(mounting_holes) staging_plate_mounting_holes(width, height, mounting_hole_offset, mounting_hole_diameter);
-                    if(grid_holes) staging_plate_grid_holes(width, height, grid_spacing, grid_offset, grid_hole_diameter);
-                    if(camera_hole) staging_plate_camera_hole(width, height, camera_hole_diameter);
+                    if(grid_holes) staging_plate_grid_holes(width, height, grid_spacing, grid_offset, (is_tapping) ? tapping_hole_diameter : grid_hole_diameter, camera_hole_tapping_exclusions);
+                    if(camera_hole) staging_plate_camera_hole(width, camera_height, camera_hole_diameter);
                 }
             }
         }
@@ -71,23 +86,25 @@ module staging_plate_mounting_holes(plate_width, plate_height, offset, diameter)
     }
 }
 
-module staging_plate_grid_holes(plate_width, plate_height, spacing, offset, diameter) {
-    grid_count_x = ceil((plate_width - offset[0] * 2) / spacing[0]);
-    grid_count_y = ceil((plate_height - offset[1] * 2) / spacing[1]);
-    grid_cutoff_x = plate_width - offset[0];
-    grid_cutoff_y = plate_height - offset[1];
+module staging_plate_grid_holes(plate_width, plate_height, spacing, offset, diameter, camera_exclusions) {
+    grid_count_x = (plate_width - offset[0] * 2) / spacing[0];
+    grid_count_y = (plate_height - offset[1] * 2) / spacing[1];
 
+    echo("grid_count_x " , grid_count_x +1);  
+    echo("grid_count_y " , grid_count_y +1);  
+    short_row_count = floor(((grid_count_y+1)/2));
+    echo("short_row_count  " , short_row_count); 
+    tapping_count = ((grid_count_y +1)* (grid_count_x +1)) - camera_exclusions - short_row_count;
+    echo("hole size " , diameter); 
+    echo("HOLES TO TAP " , tapping_count);  
+    
     translate(offset) {
         for(yn = [0:grid_count_y]) {
             stagger_x_offset = yn % 2 == 0 ? 0 : spacing[0] / 2;
             stagger_count_offset = yn % 2 == 0 ? 0 : -1;
             for(xn = [0:grid_count_x + stagger_count_offset]) {
-                _x = spacing[0] * xn + stagger_x_offset;
-                _y = spacing[1] * yn;
-                if(_x < grid_cutoff_x && _y < grid_cutoff_y) {
-                    translate([_x, spacing[1] * yn]) {
-                        circle(d = diameter);
-                    }
+                translate([spacing[0] * xn + stagger_x_offset, spacing[1] * yn]) {
+                    circle(d = diameter, $fn = 100);
                 }
             }
         }
@@ -95,8 +112,8 @@ module staging_plate_grid_holes(plate_width, plate_height, spacing, offset, diam
 };
 
 
-module staging_plate_camera_hole(plate_width, plate_height, diameter) {
-    translate([plate_width / 2, plate_height / 2]) {
+module staging_plate_camera_hole(plate_width, plate_height_for_camera, diameter) {
+    translate([plate_width / 2, plate_height_for_camera]) {
         circle(d=diameter);
     }
 }
@@ -110,5 +127,5 @@ module __staging_plate_round_those_corners_bb(r) {
 }
 
 
-staging_plate($fn=100);
+staging_plate();
 


### PR DESCRIPTION
Conceptually treats a staging plate as a unit and allows for 

1) Definition of the number of plate units you want, with the camera hole in the usual place. Doesn't have to be in whole plate sizes.

2) The ability to specify a separate size for the accessory hole if the plate is going to be tapped later. IE. usually the hole is 3.4mm but if its gonig to be tapped for M3 screws then 2.5mm

3) There is a boolean to select if the hole is tapped or not.

4) Some debug output to provide a count of the number of holes to be tapped, which is required for costing by fabrication shops.